### PR TITLE
fix: Seguindo a alteração do type de algumas colunas usadas na função

### DIFF
--- a/SQL/Functions/fn_lista_tarefa_usuario.sql
+++ b/SQL/Functions/fn_lista_tarefa_usuario.sql
@@ -25,7 +25,7 @@ BEGIN
              , tarefa.igravidade
              , tarefa.iurgencia
              , tarefa.itendencia
-             , tarefa.ntempoestimado
+             , tarefa.itempoestimado
              , tarefa.cdescricao
              , tarefa.cstatus
              , tarefa.ddataatribuicao


### PR DESCRIPTION
## 📝 Descrição

O campo iTempoEstimado da tabela de Tarefa era um DECIMAL na função, impossibilitando sua execução. Esse erro está sendo corrigido nesse PR

---

## ✅ Checklist

- [x] Código testado localmente
- [x] Nenhum erro no build
- [x] PR está seguindo a estrutura definida
- [x] Revisado por pelo menos uma pessoa

---

## 📸 Evidências (screenshots, logs, etc)
N/A
---

## 🔥 Impacto no sistema

- Alguma parte crítica foi alterada? Sim
- Pode afetar outras funcionalidades? Sim

---

## 🔗 Informações complementares
N/A
---
