### PR TITLE
Fix 36 - Retirando relação UNIQUE da tabela de logs de Usuario

### DIFF
--- a/SQL/Modelo/schema_table_log.sql
+++ b/SQL/Modelo/schema_table_log.sql
@@ -111,7 +111,6 @@ CREATE TABLE table_log.Usuario ( nCdLog        BIGSERIAL
                                , cOperacao     VARCHAR(50)
                                , dOperacao     TIMESTAMP              											  
                                , PRIMARY KEY (nCdLog)
-                               , UNIQUE (nCdUsuario)
                                );
 
 CREATE TABLE table_log.HabilidadeUsuario ( nCdLog        BIGSERIAL


### PR DESCRIPTION
## 📝 Descrição

Retirando a relação UNIQUE do campo "nCdUsuario" da tabela de logs de Usuario 
---

## ✅ Checklist

- [x] Código testado localmente
- [x] Nenhum erro no build
- [x] PR está seguindo a estrutura definida
- [x] Revisado por pelo menos uma pessoa

---

## 📸 Evidências (screenshots, logs, etc)
Se necessário, adicione imagens ou prints de execução:

---

## 🔥 Impacto no sistema

- Alguma parte crítica foi alterada?
- Pode afetar outras funcionalidades?

---

## 🔗 Informações complementares
Inclua links para tarefas relacionadas, issues ou qualquer detalhe relevante.

---
